### PR TITLE
Bug/invierto orden lista

### DIFF
--- a/server/models/movement.js
+++ b/server/models/movement.js
@@ -60,6 +60,9 @@ const getAllMovements = (limit, skip, type) => {
             exclude: ['createdAt', 'updatedAt'],
         },
         where: where,
+        order: [
+            ['id', 'DESC'],
+        ],
     });
 };
 

--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -12,10 +12,7 @@ describe('Home Test', () => {
     it('Deberia estar bien el formato del entero', () => {
         cy.visit('/');
 
-       cy.get('ul>li .level-right p').eq(1).should(($p)=>{
-            expect($p).to.contain('$ 587,5')
-
-        }) 
+        cy.get(':nth-child(1) > [data-testid=movement] > .level-right > .level-item > .has-text-danger').contains("$ 1.498")
     });
 
     it('Deberia mostrar los ultimos 5 movimientos', () => {

--- a/tests/e2e/specs/income.spec.js
+++ b/tests/e2e/specs/income.spec.js
@@ -11,9 +11,9 @@ describe('Ingresos Test', () => {
             .find('button')
             .contains('editar')
             .click();
-        cy.get('input[name=id]').should('have.value', '3');
-        cy.get('input[name=category]').should('have.value', 'Sueldo');
-        cy.get('input[name=amount]').should('have.value', '50000');
+        cy.get('input[name=id]').should('have.value', '14');
+        cy.get('input[name=category]').should('have.value', 'Plazo Fijo');
+        cy.get('input[name=amount]').should('have.value', '11000');
     });
 
     it('Deberia poder crear un nuevo ingreso', () => {

--- a/tests/integration/index.test.js
+++ b/tests/integration/index.test.js
@@ -62,7 +62,7 @@ test('Buscar movimientos por api con un resultado', async () => {
     };
 
     // Creamos los movimientos
-    const firstMovement = await MovementModel.create(firstMovementData);
+    await MovementModel.create(firstMovementData);
     const secondMovement=await MovementModel.create(secondMovementData);
 
     const URL = `${baseURL}/movements?limit=1`;
@@ -90,7 +90,7 @@ test('Buscar movimientos por api con offset', async () => {
 
     // Creamos los movimientos
     const firstMovement=await MovementModel.create(firstMovementData);
-    const secondMovement = await MovementModel.create(secondMovementData);
+    await MovementModel.create(secondMovementData);
 
     const URL = `${baseURL}/movements?limit=1&page=2`;
     const req = await fetch(URL);

--- a/tests/integration/index.test.js
+++ b/tests/integration/index.test.js
@@ -63,7 +63,7 @@ test('Buscar movimientos por api con un resultado', async () => {
 
     // Creamos los movimientos
     const firstMovement = await MovementModel.create(firstMovementData);
-    await MovementModel.create(secondMovementData);
+    const secondMovement=await MovementModel.create(secondMovementData);
 
     const URL = `${baseURL}/movements?limit=1`;
     const req = await fetch(URL);
@@ -71,7 +71,7 @@ test('Buscar movimientos por api con un resultado', async () => {
 
     expect(req.status).toBe(200);
     expect(body.movements.length).toBe(1);
-    expect(firstMovement.id).toBe(body.movements[0].id);
+    expect(secondMovement.id).toBe(body.movements[0].id);
 });
 
 test('Buscar movimientos por api con offset', async () => {
@@ -89,7 +89,7 @@ test('Buscar movimientos por api con offset', async () => {
     };
 
     // Creamos los movimientos
-    await MovementModel.create(firstMovementData);
+    const firstMovement=await MovementModel.create(firstMovementData);
     const secondMovement = await MovementModel.create(secondMovementData);
 
     const URL = `${baseURL}/movements?limit=1&page=2`;
@@ -97,7 +97,7 @@ test('Buscar movimientos por api con offset', async () => {
     const response = await req.json();
 
     expect(response.movements.length).toBe(1);
-    expect(secondMovement.id).toBe(response.movements[0].id);
+    expect(firstMovement.id).toBe(response.movements[0].id);
 });
 
 test('Buscar movimientos por api filtrando por tipo income', async () => {

--- a/tests/unit/models.spec.js
+++ b/tests/unit/models.spec.js
@@ -130,7 +130,7 @@ test('Listar movimientos con limite', async () => {
     };
 
     // Creamos los movimientos
-    const movement = await MovementModel.create(firstMovementData);
+    await MovementModel.create(firstMovementData);
     const movement2=await MovementModel.create(secondMovementData);
 
     let movements = await MovementModel.getAll(1);
@@ -157,7 +157,7 @@ test('Listar movimientos con limite y offset', async () => {
 
     // Creamos los movimientos
     const firstMovement=await MovementModel.create(firstMovementData);
-    const secondMovement = await MovementModel.create(secondMovementData);
+    await MovementModel.create(secondMovementData);
 
     let movements = await MovementModel.getAll(1, 1);
 

--- a/tests/unit/models.spec.js
+++ b/tests/unit/models.spec.js
@@ -68,6 +68,29 @@ test('Crear movimiento sin fecha', async () => {
     }
 });
 
+test('Obtener movimientos de manera descendente', async () => {
+    const movementData1 = {
+        date: '04/01/2021',
+        amount: 50000.0,
+        type: MovementType.INCOME,
+        category: 'Sueldo',
+    };
+    const movementData2 = {
+        date: '04/01/2021',
+        amount: 300.0,
+        type: MovementType.EXPENSE,
+        category: 'Transporte',
+    };
+
+    // Creamos los movimiento
+    const movement1 = await MovementModel.create(movementData1);
+    const movement2 = await MovementModel.create(movementData2);
+    const movements = await MovementModel.getAll();
+    expect(movements.rows[0].id).toBe(movement2.id)
+    expect(movements.rows[1].id).toBe(movement1.id)
+
+});
+
 test('Listar movimientos sin resultados', async () => {
     const movements = await MovementModel.getAll();
 
@@ -108,13 +131,13 @@ test('Listar movimientos con limite', async () => {
 
     // Creamos los movimientos
     const movement = await MovementModel.create(firstMovementData);
-    await MovementModel.create(secondMovementData);
+    const movement2=await MovementModel.create(secondMovementData);
 
     let movements = await MovementModel.getAll(1);
 
-    // La lista de movimientos debería contener solo el primero
+    // La lista de movimientos debería contener solo el segundo movimiento
     expect(movements.rows.length).toBe(1);
-    expect(movements.rows[0].id).toBe(movement.id);
+    expect(movements.rows[0].id).toBe(movement2.id);
 });
 
 test('Listar movimientos con limite y offset', async () => {
@@ -133,14 +156,14 @@ test('Listar movimientos con limite y offset', async () => {
     };
 
     // Creamos los movimientos
-    await MovementModel.create(firstMovementData);
-    const movement = await MovementModel.create(secondMovementData);
+    const firstMovement=await MovementModel.create(firstMovementData);
+    const secondMovement = await MovementModel.create(secondMovementData);
 
     let movements = await MovementModel.getAll(1, 1);
 
-    // La lista de movimientos debería contener solo el segundo
+    // La lista de movimientos debería contener solo el primer movimiento
     expect(movements.rows.length).toBe(1);
-    expect(movements.rows[0].id).toBe(movement.id);
+    expect(movements.rows[0].id).toBe(firstMovement.id);
 });
 
 test('Filtrar movimientos por tipo income', async () => {


### PR DESCRIPTION
Arreglo el bug que hace que los movimientos que se traen del modelo sean los 5 mas antiguos, ahora trae los 5 mas recientes. Para ello tuve que modificar el modelo, ordenando por id y tuve que modificar los tests unitarios y de integracion que estaban relacionados.

Agregue un test para verificar que trae los movimientos ordenados de forma descendente