### PR TITLE
Modifico el criterio de orden de id a fecha y arreglo tests correspondientes

### DIFF
--- a/server/models/movement.js
+++ b/server/models/movement.js
@@ -65,7 +65,7 @@ const getAllMovements = (limit, skip, type) => {
         },
         where: where,
         order: [
-            ['id', 'DESC'],
+            ['date', 'DESC'],
         ],
     });
 };
@@ -84,7 +84,7 @@ const createMovement = ({
     recurrent = false,
 } = {}) => {
 
-    //debo cambiar el formato de fecha para que no rompa el fixtures
+    //debo cambiar el formato de fecha para que no rompa el fixture
     date=date.split("/")!=-1?(
         //viene del fixture y tengo que cambiarlo
         `${date.split("/")[2]}-${date.split("/")[1]}-${date.split("/")[0]}`

--- a/tests/unit/models.spec.js
+++ b/tests/unit/models.spec.js
@@ -76,7 +76,7 @@ test('Obtener movimientos de manera descendente', async () => {
         category: 'Sueldo',
     };
     const movementData2 = {
-        date: '04/01/2021',
+        date: '04/02/2021',
         amount: 300.0,
         type: MovementType.EXPENSE,
         category: 'Transporte',
@@ -165,7 +165,7 @@ test('Listar movimientos con limite y offset', async () => {
     };
 
     const secondMovementData = {
-        date: '04/01/2021',
+        date: '05/01/2021',
         amount: 50000.0,
         type: MovementType.INCOME,
         category: 'Sueldo',


### PR DESCRIPTION
Previamente tenia como criterio de orden la id que se le asignaba en la creacion al movimiento, ahora con la fecha del formulario funcional, la ordeno por ese atributo